### PR TITLE
fix: Update XMC genesis timestamp and safety buffer in RestoreHeight

### DIFF
--- a/app/src/main/java/com/m2049r/xmrwallet/util/RestoreHeight.java
+++ b/app/src/main/java/com/m2049r/xmrwallet/util/RestoreHeight.java
@@ -25,7 +25,7 @@ import java.util.TimeZone;
 public class RestoreHeight {
     // XMC parameters
     static final int DIFFICULTY_TARGET = 120; // seconds per block
-    static final long XMC_GENESIS_TIMESTAMP = 1734393600L; // 2024-12-17 00:00:00 UTC (seconds)
+    static final long XMC_GENESIS_TIMESTAMP = 1734424522L; // 2024-12-17 08:35:22 UTC (seconds)
     
     static private RestoreHeight Singleton = null;
 
@@ -74,8 +74,8 @@ public class RestoreHeight {
         // Calculate estimated height based on time difference
         long timeDiff = targetTimestamp - XMC_GENESIS_TIMESTAMP;
         long estimatedHeight = timeDiff / DIFFICULTY_TARGET;
-        
-        // Return estimated height with some safety buffer (subtract ~1 day worth of blocks)
-        return Math.max(0, estimatedHeight - 720); // 720 blocks ≈ 1 day at 120s per block
+
+        // Return estimated height with some safety buffer (subtract ~30 day worth of blocks)
+        return Math.max(0, estimatedHeight - 21600); // 21600 blocks ≈ 30 day at 120s per block
     }
 }


### PR DESCRIPTION
- Update XMC_GENESIS_TIMESTAMP from 1734393600 to 1734424522
  * Changed from 2024-12-17 00:00:00 UTC to 2024-12-17 08:35:22 UTC
  * Reflects actual XMC network genesis time for accurate height calculation

- Increase safety buffer from 1 day to 30 days
  * Changed from 720 blocks to 21600 blocks (30 days × 24 hours × 60 minutes / 2 minutes per block)
  * Provides larger margin to ensure no transactions are missed during wallet restoration
  * Better accommodates potential clock skew and network variations

These changes improve wallet restoration accuracy and reliability for XMC users.